### PR TITLE
Fix slugFormatter test name typo

### DIFF
--- a/packages/utils/src/slugFormatter.test.ts
+++ b/packages/utils/src/slugFormatter.test.ts
@@ -22,7 +22,7 @@ describe('slugFormatter', () => {
     expect(slugFormatter({ slug: '' })).toEqual('/')
   })
 
-  it('should return an extranal url', () => {
+  it('should return an external url', () => {
     expect(slugFormatter({ slug: 'https://example.com' })).toEqual(
       'https://example.com'
     )


### PR DESCRIPTION
## Summary
- fix a typo in slugFormatter test name ('extranal' -> 'external')

## Testing
- `git status --short`