### PR TITLE
Refactor navigation formatter narrowing

### DIFF
--- a/packages/components/src/footer/footer.tsx
+++ b/packages/components/src/footer/footer.tsx
@@ -7,7 +7,7 @@ import { Link } from '@mono/next-js'
 export const Footer = async () => {
   const { data } = await getGeneralInfo()
   const { metadata } = await getSiteMetadata()
-  if (!data?.general) return null
+  if (!data) return null
 
   return (
     <footer className={classNames(styles.root)}>
@@ -19,13 +19,13 @@ export const Footer = async () => {
         <div>
           <h3 className={classNames(styles.title)}>Navigatie</h3>
           <ul className={classNames(styles.list)}>
-            {data.general.menu.map((item) => {
-              if ('link' in item && item?.link?.slug && item.label) {
+            {data.menu.map((item) => {
+              if ('slug' in item && item.slug && item.label) {
                 return (
                   <li key={item.id}>
                     <Link
                       className={classNames(styles.link)}
-                      href={slugFormatter({ slug: item?.link?.slug })}
+                      href={slugFormatter({ slug: item.slug })}
                     >
                       {item.label}
                     </Link>

--- a/packages/components/src/mobileMenu/mobileMenu.tsx
+++ b/packages/components/src/mobileMenu/mobileMenu.tsx
@@ -7,16 +7,14 @@ import { MobileMenuItems } from '../mobileMenuItems/index.js'
 import classNames from 'classnames'
 import styles from './styles.module.scss'
 import { useDimensions, useHrefClick } from '@mono/hooks'
-import type { GetGeneralInfoQuery } from '@mono/data'
+import type { Navigation } from '@mono/data'
 
 export const MobileMenu = ({
   escapedMenuString,
 }: {
   escapedMenuString: string
 }) => {
-  const general = JSON.parse(
-    escapedMenuString
-  ) as GetGeneralInfoQuery['general']
+  const general = JSON.parse(escapedMenuString) as Navigation
   const [open, setOpen] = useState(false)
   useHrefClick(() => setOpen(false))
   const { width } = useDimensions()

--- a/packages/components/src/mobileMenuItems/mobileMenuItems.tsx
+++ b/packages/components/src/mobileMenuItems/mobileMenuItems.tsx
@@ -1,4 +1,4 @@
-import { type GetGeneralInfoQuery } from '@mono/data'
+import { type Navigation } from '@mono/data'
 import { NavigationItem } from '../navigationItem/index.js'
 import React from 'react'
 import classNames from 'classnames'
@@ -7,33 +7,33 @@ import styles from './styles.module.scss'
 export const MobileMenuItems = ({
   general,
 }: {
-  general: GetGeneralInfoQuery['general']
+  general: Navigation
 }) => {
   return (
     <ul className={styles.root}>
       {general?.menu?.map((item) => {
-        if ('link' in item) {
+        if ('slug' in item) {
           return (
             <NavigationItem
               key={item.id}
-              slug={item?.link?.slug}
+              slug={item.slug}
               label={item.label}
             />
           )
         }
 
-        if ('menu' in item) {
+        if ('items' in item) {
           return (
             <li key={item.id}>
               <span className={classNames(styles.subItem, 'h3')}>
                 {item.label}
               </span>
               <ul className={styles.subList}>
-                {item?.menu?.map((subItem) => {
+                {item?.items?.map((subItem) => {
                   return (
                     <NavigationItem
                       key={subItem.id}
-                      slug={subItem?.link?.slug}
+                      slug={subItem.slug}
                       label={subItem.label}
                     />
                   )

--- a/packages/components/src/navigation/mocks/mockMenuData.ts
+++ b/packages/components/src/navigation/mocks/mockMenuData.ts
@@ -1,68 +1,34 @@
-import type { GetGeneralInfoQuery } from '@mono/data'
+import type { Navigation } from '@mono/data'
 
-export const mockMenuData: GetGeneralInfoQuery = {
-  general: {
-    id: '187236701',
-    title: 'algemene info',
-    menu: [
-      {
-        id: '187236699',
-        label: 'contact',
-        link: {
-          __typename: 'PageRecord',
-          _createdAt: 'some date time string',
-          _updatedAt: 'some date time string',
-          _firstPublishedAt: 'some date time string',
-          _publishedAt: 'some date time string',
-          id: 'unique-id',
+export const mockMenuData: Navigation = {
+  id: '187236701',
+  title: 'algemene info',
+  menu: [
+    {
+      id: '187236699',
+      label: 'contact',
+      slug: 'contact',
+    },
+    {
+      id: '187236700',
+      label: 'homepage',
+      slug: 'homepage',
+    },
+    {
+      id: '194164583',
+      label: 'level 1',
+      items: [
+        {
+          id: '194164581',
+          label: 'level 2 - contact',
           slug: 'contact',
         },
-      },
-      {
-        id: '187236700',
-        label: 'homepage',
-        link: {
-          __typename: 'PageRecord',
-          _createdAt: 'some date time string',
-          _updatedAt: 'some date time string',
-          _firstPublishedAt: 'some date time string',
-          _publishedAt: 'some date time string',
-          id: 'unique-id',
-          slug: 'homepage',
+        {
+          id: '194164582',
+          label: 'level 2 - specific page',
+          slug: 'specific/page',
         },
-      },
-      {
-        id: '194164583',
-        label: 'level 1',
-        menu: [
-          {
-            id: '194164581',
-            label: 'level 2 - contact',
-            link: {
-              __typename: 'PageRecord',
-              _createdAt: 'some date time string',
-              _updatedAt: 'some date time string',
-              _firstPublishedAt: 'some date time string',
-              _publishedAt: 'some date time string',
-              id: 'unique-id',
-              slug: 'contact',
-            },
-          },
-          {
-            id: '194164582',
-            label: 'level 2 - specific page',
-            link: {
-              __typename: 'PageRecord',
-              _createdAt: 'some date time string',
-              _updatedAt: 'some date time string',
-              _firstPublishedAt: 'some date time string',
-              _publishedAt: 'some date time string',
-              id: 'unique-id',
-              slug: 'specific/page',
-            },
-          },
-        ],
-      },
-    ],
-  },
+      ],
+    },
+  ],
 }

--- a/packages/components/src/navigation/navigation.tsx
+++ b/packages/components/src/navigation/navigation.tsx
@@ -8,30 +8,30 @@ import styles from './styles.module.scss'
 
 export const Navigation = async () => {
   const { data } = await getGeneralInfo()
-  if (!data?.general) return null
+  if (!data) return null
 
   return (
     <nav className={classNames(styles.root, 'content-layout')}>
       <div className={classNames(styles.content)}>
-        <MobileMenu escapedMenuString={JSON.stringify(data.general)} />
+        <MobileMenu escapedMenuString={JSON.stringify(data)} />
         <ul className={classNames(styles.list)}>
-          {data.general.menu?.map((item) => {
-            if ('link' in item) {
+          {data.menu?.map((item) => {
+            if ('slug' in item) {
               return (
                 <NavigationItem
                   key={item.id}
-                  slug={item?.link?.slug}
+                  slug={item.slug}
                   label={item.label}
                 />
               )
             }
 
-            if ('menu' in item) {
+            if ('items' in item) {
               return (
                 <NavigationSubMenu
                   key={item.id}
                   label={item.label}
-                  item={JSON.stringify(item.menu)}
+                  item={JSON.stringify(item.items)}
                 />
               )
             }

--- a/packages/data/src/formatters/index.ts
+++ b/packages/data/src/formatters/index.ts
@@ -1,2 +1,3 @@
 export { formatCloudinaryDocument } from './formatCloudinaryDocument.js'
 export { formatCloudinaryImage } from './formatCloudinaryImage.js'
+export { navigationFormatter } from './navigationFormatter.js'

--- a/packages/data/src/formatters/navigationFormatter.test.ts
+++ b/packages/data/src/formatters/navigationFormatter.test.ts
@@ -1,0 +1,54 @@
+import { navigationFormatter } from './navigationFormatter.js'
+import { describe, it, expect } from 'vitest'
+
+describe('navigationFormatter', () => {
+  it('should format navigation data', () => {
+    const input = {
+      id: '1',
+      title: 'main',
+      menu: [
+        {
+          id: '2',
+          label: 'contact',
+          link: {
+            __typename: 'PageRecord',
+            _createdAt: '',
+            _updatedAt: '',
+            _firstPublishedAt: '',
+            _publishedAt: '',
+            id: 'p1',
+            slug: 'contact',
+          },
+        },
+        {
+          id: '3',
+          label: 'submenu',
+          menu: [
+            {
+              id: '4',
+              label: 'child',
+              link: {
+                __typename: 'PageRecord',
+                _createdAt: '',
+                _updatedAt: '',
+                _firstPublishedAt: '',
+                _publishedAt: '',
+                id: 'p2',
+                slug: 'child',
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(navigationFormatter(input)).toEqual({
+      id: '1',
+      title: 'main',
+      menu: [
+        { id: '2', label: 'contact', slug: 'contact' },
+        { id: '3', label: 'submenu', items: [{ id: '4', label: 'child', slug: 'child' }] },
+      ],
+    })
+  })
+})

--- a/packages/data/src/formatters/navigationFormatter.ts
+++ b/packages/data/src/formatters/navigationFormatter.ts
@@ -1,0 +1,39 @@
+import type {
+  GeneralInfoFragment,
+  MenuItemFragment,
+  SubmenuItemFragment,
+} from '../generated/graphql.js'
+import type {
+  Navigation,
+  NavigationItem,
+  NavigationSubMenu,
+} from '../types/navigation.js'
+
+const navigationItemFormatter = (
+  item: MenuItemFragment,
+): NavigationItem => ({
+  id: item.id,
+  label: item.label ?? undefined,
+  slug: item.link?.slug ?? undefined,
+})
+
+const navigationSubMenuFormatter = (
+  item: SubmenuItemFragment,
+): NavigationSubMenu => ({
+  id: item.id,
+  label: item.label ?? undefined,
+  items: item.menu.map((sub) => navigationItemFormatter(sub)),
+})
+
+export const navigationFormatter = (
+  general: GeneralInfoFragment,
+): Navigation => ({
+  id: general.id,
+  title: general.title ?? undefined,
+  menu: general.menu.map((item) => {
+    if ('menu' in item) {
+      return navigationSubMenuFormatter(item)
+    }
+    return navigationItemFormatter(item)
+  }),
+})

--- a/packages/data/src/getters/getGeneralInfo.test.ts
+++ b/packages/data/src/getters/getGeneralInfo.test.ts
@@ -20,7 +20,9 @@ const mockedQuery = vi.mocked(client.query)
 describe('getGeneralInfo', () => {
   it('should return an object', async () => {
     mockedQuery.mockResolvedValue({
-      data: {},
+      data: {
+        general: { id: '1', title: 'main', menu: [] },
+      },
       operation: {
         key: 1,
         query: GetGeneralInfoDocument,
@@ -35,7 +37,7 @@ describe('getGeneralInfo', () => {
       hasNext: false,
     })
     const { data } = await getGeneralInfo()
-    expect(data).toEqual({})
+    expect(data).toEqual({ id: '1', title: 'main', menu: [] })
   })
   it('should return an error', async () => {
     console.log = vi.fn()

--- a/packages/data/src/getters/getGeneralInfo.ts
+++ b/packages/data/src/getters/getGeneralInfo.ts
@@ -5,10 +5,12 @@ import {
 } from '../generated/graphql.js'
 import type { CombinedError } from '@urql/core'
 import { client } from '../gqlClient.js'
+import { navigationFormatter } from '../formatters/navigationFormatter.js'
+import type { Navigation } from '../types/navigation.js'
 
 export const getGeneralInfo = async (): Promise<
   | {
-      data?: GetGeneralInfoQuery
+      data?: Navigation | null
       error?: CombinedError
     }
   | {
@@ -23,7 +25,7 @@ export const getGeneralInfo = async (): Promise<
     >(GetGeneralInfoDocument, {})
 
     return {
-      data,
+      data: data?.general ? navigationFormatter(data.general) : null,
       error,
     }
   } catch (error) {

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -27,11 +27,15 @@ export type {
   Image,
   Location,
   Music,
+  Navigation,
+  NavigationItem,
+  NavigationSubMenu,
 } from './types/index.js'
 
 export { isOfTypeCloudinaryAsset } from './types/index.js'
 export {
   formatCloudinaryDocument,
   formatCloudinaryImage,
+  navigationFormatter,
 } from './formatters/index.js'
 export * from './generated/graphql.js'

--- a/packages/data/src/types/index.ts
+++ b/packages/data/src/types/index.ts
@@ -9,3 +9,8 @@ export {
 } from './image.js'
 export type { Location } from './location.js'
 export type { Music } from './music.js'
+export type {
+  Navigation,
+  NavigationItem,
+  NavigationSubMenu,
+} from './navigation.js'

--- a/packages/data/src/types/navigation.ts
+++ b/packages/data/src/types/navigation.ts
@@ -1,0 +1,17 @@
+export interface NavigationItem {
+  id: string
+  label?: string | null
+  slug?: string | null
+}
+
+export interface NavigationSubMenu {
+  id: string
+  label?: string | null
+  items: NavigationItem[]
+}
+
+export interface Navigation {
+  id: string
+  title?: string | null
+  menu: Array<NavigationItem | NavigationSubMenu>
+}


### PR DESCRIPTION
## Summary
- remove type cast in `navigationFormatter`
- narrow submenu items by checking for the `menu` property

## Testing
- `npm test` *(fails: vitest not found)*