### PR TITLE
fix: useDimensions effect dependency

### DIFF
--- a/packages/hooks/src/useDimensions.ts
+++ b/packages/hooks/src/useDimensions.ts
@@ -35,7 +35,7 @@ export const useDimensions = () => {
       document.removeEventListener('load', handleLoad)
       resizeObserver.disconnect()
     }
-  }, [setDimensions])
+  }, [])
 
   return dimensions
 }


### PR DESCRIPTION
## Summary
- avoid re-running `useDimensions` effect by removing stable `setDimensions` from deps

## Testing
- `npm test --workspaces --if-present` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684802b9327c8322a1fd8e3e6b41f24a