### PR TITLE
chore: exclude CHANGELOG.md from oxfmt formatting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": []
+  "ignorePatterns": ["CHANGELOG.md"]
 }


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` to `ignorePatterns` in `.oxfmtrc.json` so the changelog is excluded from oxfmt formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)